### PR TITLE
Added OpenAI embeddings support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,14 +14,33 @@ REPO_ROOT=C:/path/to/your/repository
 #FOLDER_INFO_NAME=REPO_ROOT
 
 # Optional: Location to cache transformer models to speed up runs.
+# Only used when EMBEDDING_PROVIDER=local.
 TRANSFORMERS_CACHE=C:/path/to/cache
 
+# Optional: Embedding backend.
+#   local  = load a model through @huggingface/transformers (default)
+#   openai = call an OpenAI-compatible /embeddings API (OpenAI, Mistral, Jina AI, etc.)
+#EMBEDDING_PROVIDER=local
+
 # Optional: Embedding model name. Precedence: constructor arg > MODEL_NAME env > default.
-# Default model: jinaai/jina-embeddings-v2-base-code
-# Alternative examples:
+# Local default model: jinaai/jina-embeddings-v2-base-code
+# Local alternative examples:
 #   MODEL_NAME=Xenova/bge-base-en-v1.5        # Strong English text focus
 #   MODEL_NAME=Xenova/bge-small-en-v1.5       # Faster/lower memory English
+# OpenAI-compatible API example:
+#   MODEL_NAME=text-embedding-3-large
 #MODEL_NAME=jinaai/jina-embeddings-v2-base-code
+
+# Required when EMBEDDING_PROVIDER=openai.
+# Set the provider base URL, not the /embeddings path itself.
+# Examples:
+#   EMBEDDING_API_BASE_URL=https://api.openai.com/v1
+#   EMBEDDING_API_BASE_URL=https://api.mistral.ai/v1
+#EMBEDDING_API_BASE_URL=
+
+# Required when EMBEDDING_PROVIDER=openai.
+# Bearer token used for the OpenAI-compatible embeddings API.
+#EMBEDDING_API_KEY=
 
 # Optional: Comma-separated list of allowed file extensions to index.
 # Example: ts,tsx,js,jsx,py,cs,java,kt,kts,md,gradle,json,yaml,yml,xml,proto,properties

--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,11 @@ TRANSFORMERS_CACHE=C:/path/to/cache
 # Bearer token used for the OpenAI-compatible embeddings API.
 #EMBEDDING_API_KEY=
 
+# Optional when EMBEDDING_PROVIDER=openai.
+# Number of inputs to send in one remote embeddings request during indexing.
+# Default: 200
+#EMBEDDING_API_BATCH_SIZE=200
+
 # Optional: Comma-separated list of allowed file extensions to index.
 # Example: ts,tsx,js,jsx,py,cs,java,kt,kts,md,gradle,json,yaml,yml,xml,proto,properties
 #ALLOWED_EXT=
@@ -69,14 +74,14 @@ TRANSFORMERS_CACHE=C:/path/to/cache
 #ALLOWED_HOSTS=127.0.0.1,localhost
 
 # Optional: Chunk sizing for indexing (character based, before embedding)
-# Default chunk size 800 with 120 overlap generally balances context retention and total
-# embedding count for mixed code + docs. You can tune:
-#   Larger chunks (1000-1400) -> fewer embeddings, slightly less recall on very small functions
-#   Smaller chunks (400-600)  -> more granular matches but higher memory + build time
-# Overlap should usually be 10-20% of chunk size (e.g., 80-160 for 800) to keep semantic continuity.
+# Default chunk size 2400 with 400 overlap generally maps to about 800 / 120 tokens
+# for mixed code + docs. You can tune:
+#   Larger chunks (3000-4200) -> fewer embeddings, slightly less recall on very small functions
+#   Smaller chunks (1200-1800) -> more granular matches but higher memory + build time
+# Overlap should usually be 10-20% of chunk size (e.g., 240-540 for 2400) to keep semantic continuity.
 # Hard upper safety caps: chunk size <= 8000, overlap <= 4000.
-#CHUNK_SIZE=800
-#CHUNK_OVERLAP=120
+#CHUNK_SIZE=2400
+#CHUNK_OVERLAP=400
 
 # Optional: Persist the embedding index to disk for warm starts + incremental reindex
 # When set, startup loads the index (if compatible) then only re-embeds new / deleted / size-changed files.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `mcp-rag-server` is a lightweight Retrieval‑Augmented Generation helper you can plug into **any client that speaks the [Model Context Protocol (MCP)]**. GitHub Copilot Agent mode in Visual Studio / VS Code is just one option – you can also use the official MCP Inspector, future MCP‑aware IDEs, or custom tooling.
 
-It indexes a target repository directory, chunks the content (default chunk size **800** chars with **120** char overlap – both configurable via `CHUNK_SIZE` / `CHUNK_OVERLAP`), builds embeddings using either **local inference** via `@huggingface/transformers` or an **OpenAI‑compatible embeddings API**, and exposes MCP tools:
+It indexes a target repository directory, chunks the content (default chunk size **2400** characters, about **800** tokens, with **400** characters of overlap, about **120** tokens; both configurable via `CHUNK_SIZE` / `CHUNK_OVERLAP`), builds embeddings using either **local inference** via `@huggingface/transformers` or an **OpenAI‑compatible embeddings API**, and exposes MCP tools:
 
 - `rag_query` – semantic search returning scored snippets (path, score, snippet)
 - `read_file` – secure file read (optional line range) constrained to `REPO_ROOT`. For PDF files, text is automatically retrieved from the unified cache file if available
@@ -316,11 +316,11 @@ Supported variables:
 - `MCP_PORT` (optional, HTTP mode): TCP port (default `3000`).
 - `ENABLE_DNS_REBINDING_PROTECTION` (optional, HTTP mode): defaults to `true`; set to `false` to disable host allow‑list checks.
 - `ALLOWED_HOSTS` (optional, HTTP mode): comma-separated list of hosts allowed when DNS rebinding protection is enabled. Defaults include localhost and 127.0.0.1 with/without port.
-- `CHUNK_SIZE` (optional): maximum characters per chunk before embedding (default 800). Larger values reduce total embeddings (faster build, less memory) but can blur fine-grained matches. Typical ranges:
-  - 700‑900 (balanced default)
-  - 1000‑1400 (large prose / long functions; fewer vectors)
-  - 400‑600 (fine‑grained code navigation; more vectors / memory)
-- `CHUNK_OVERLAP` (optional): trailing characters carried into the next chunk (default 120 ≈ 15%). Recommended 10‑20% of `CHUNK_SIZE` (e.g., 80‑160 for an 800 size). Increase slightly (up to ~20‑25%) if you observe answers missing cross‑boundary context; decrease to speed up builds.
+- `CHUNK_SIZE` (optional): maximum characters per chunk before embedding (default 2400, roughly 800 tokens depending on tokenizer/model). Larger values reduce total embeddings (faster build, less memory) but can blur fine-grained matches. Typical ranges:
+	- 2100‑2700 (roughly 700‑900 tokens; balanced default)
+	- 3000‑4200 (roughly 1000‑1400 tokens; large prose / long functions; fewer vectors)
+	- 1200‑1800 (roughly 400‑600 tokens; fine‑grained code navigation; more vectors / memory)
+- `CHUNK_OVERLAP` (optional): trailing characters carried into the next chunk (default 400, roughly 120 tokens or about 15% of the default chunk size). Recommended 10‑20% of `CHUNK_SIZE` (for example 240‑540 when `CHUNK_SIZE=2400`). Increase slightly (up to ~20‑25%) if you observe answers missing cross‑boundary context; decrease to speed up builds.
 
 Safety caps: `CHUNK_SIZE` is clamped to 8000 and `CHUNK_OVERLAP` to 4000; if overlap >= size it's automatically reduced (logged) to preserve forward progress.
 
@@ -404,11 +404,11 @@ Feel free to experiment—swap via `MODEL_NAME` and rebuild the embedding cache 
 
 ### Chunk sizing guidance
 
-Why 800 / 120? Empirically this keeps most self‑contained code constructs (functions/classes) and short doc sections in a single chunk while providing enough continuity for cross‑block semantic matches. Adjust based on corpus:
+Why ~800 / 120 tokens? The implementation chunks by characters, so the defaults are 2400 / 400 characters, which is roughly 800 / 120 tokens for typical code and prose. Empirically this keeps most self‑contained code constructs (functions/classes) and short doc sections in a single chunk while providing enough continuity for cross‑block semantic matches. Adjust based on corpus:
 
 - Mostly short functions or config files: smaller chunks (500‑700) aid pinpoint retrieval.
 - Large narrative docs / design specs: larger chunks (1000‑1400) reduce vector count without much recall loss.
-- Heavily interdependent code where context spans multiple files: keep default or modestly raise overlap (to ~160) rather than shrinking size.
+- Heavily interdependent code where context spans multiple files: keep default or modestly raise overlap (to ~500‑600 characters) rather than shrinking size.
 
 Rule of thumb: Overlap ≈ 15% of size. Avoid overlap >= size (auto‑corrected) and avoid extremely small sizes (<300) unless you have a downstream re‑ranking stage.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# mcp-rag-server (local RAG MCP server for any repository)
+# mcp-rag-server (RAG MCP server for any repository)
 
-`mcp-rag-server` is a lightweight, zero‑network (after model download) Retrieval‑Augmented Generation helper you can plug into **any client that speaks the [Model Context Protocol (MCP)]**. GitHub Copilot Agent mode in Visual Studio / VS Code is just one option – you can also use the official MCP Inspector, future MCP‑aware IDEs, or custom tooling.
+`mcp-rag-server` is a lightweight Retrieval‑Augmented Generation helper you can plug into **any client that speaks the [Model Context Protocol (MCP)]**. GitHub Copilot Agent mode in Visual Studio / VS Code is just one option – you can also use the official MCP Inspector, future MCP‑aware IDEs, or custom tooling.
 
-It indexes a target repository directory, chunks the content (default chunk size **800** chars with **120** char overlap – both configurable via `CHUNK_SIZE` / `CHUNK_OVERLAP`), builds **local embeddings** using `@huggingface/transformers`, and exposes MCP tools:
+It indexes a target repository directory, chunks the content (default chunk size **800** chars with **120** char overlap – both configurable via `CHUNK_SIZE` / `CHUNK_OVERLAP`), builds embeddings using either **local inference** via `@huggingface/transformers` or an **OpenAI‑compatible embeddings API**, and exposes MCP tools:
 
 - `rag_query` – semantic search returning scored snippets (path, score, snippet)
 - `read_file` – secure file read (optional line range) constrained to `REPO_ROOT`. For PDF files, text is automatically retrieved from the unified cache file if available
@@ -15,7 +15,7 @@ Two transports are supported (select with `MCP_TRANSPORT=stdio|http`):
 
 ## Features
 
-- Pure local embedding inference (no external API calls) via `@huggingface/transformers`
+- Embeddings via local inference (`@huggingface/transformers`) or an OpenAI‑compatible API
 - Multi‑language source + docs support (configurable via `ALLOWED_EXT`)
 - **PDF support**: Automatically extracts text from PDF files during indexing and caches it in a unified `pdf-text-cache.json` file (located alongside the index store) for fast retrieval. PDF text is treated like any other text file for semantic search
 - Excluded folder patterns support (configurable via `EXCLUDED_FOLDERS`)
@@ -26,7 +26,7 @@ Two transports are supported (select with `MCP_TRANSPORT=stdio|http`):
 - Incremental change detection (additions / deletions / file size changes) to avoid full rebuilds
 - Stdio or Streamable HTTP transport (with optional host allow‑list / DNS rebinding protection)
 - Safe path handling (rejects attempts to escape `REPO_ROOT`)
-- Minimal dependencies; quick startup after first model load
+- Minimal dependencies; quick startup after first local model load or remote API validation
 - Ready for extension: add new MCP tools or ANN / hybrid retrieval backends
 
 Planned / Nice‑to‑have: hybrid BM25 + embedding search, ANN acceleration (HNSW / IVF), per‑language tokenizer heuristics, batched / parallel embedding, semantic boundary aware chunking.
@@ -78,6 +78,38 @@ Optionally set a model cache to speed up subsequent runs (first start downloads 
 export TRANSFORMERS_CACHE="/path/to/cache"   # macOS/Linux
 $env:TRANSFORMERS_CACHE="C:\path\to\cache" # Windows PowerShell
 ```
+
+### OpenAI-compatible API embeddings
+
+Set `EMBEDDING_PROVIDER=openai` to call a remote `/embeddings` endpoint instead of loading a local transformer model. The request format follows the OpenAI embeddings API and works with providers that expose a compatible protocol such as OpenAI, Mistral, and Jina AI.
+
+Windows PowerShell:
+
+```powershell
+$env:REPO_ROOT="C:\path\to\your-repo"
+$env:EMBEDDING_PROVIDER="openai"
+$env:EMBEDDING_API_BASE_URL="https://api.openai.com/v1"
+$env:EMBEDDING_API_KEY="<your-api-key>"
+$env:MODEL_NAME="text-embedding-3-large"
+npm start
+```
+
+macOS / Linux:
+
+```bash
+export REPO_ROOT="/path/to/your-repo"
+export EMBEDDING_PROVIDER="openai"
+export EMBEDDING_API_BASE_URL="https://api.openai.com/v1"
+export EMBEDDING_API_KEY="<your-api-key>"
+export MODEL_NAME="text-embedding-3-large"
+npm start
+```
+
+Notes:
+
+- `EMBEDDING_API_BASE_URL` should point to the provider's API base (for example `https://api.openai.com/v1`), not the `/embeddings` path itself.
+- `MODEL_NAME` is passed verbatim to the remote embeddings API when `EMBEDDING_PROVIDER=openai`.
+- `TRANSFORMERS_CACHE` is only relevant for local inference.
 
 ### Streamable HTTP mode (recommended for large initial indexes)
 
@@ -161,8 +193,8 @@ export REPO_ROOT="/path/to/your-repo"; MCP_TRANSPORT=http npx @modelcontextproto
 
 Notes:
 
-- First run downloads the embedding model and builds embeddings; the Inspector will connect only after startup completes. Watch the terminal for progress logs printed to stderr.
-- You can also put settings in a `.env` file at the project root (e.g., `REPO_ROOT`, `TRANSFORMERS_CACHE`).
+- First run in local mode downloads the embedding model and builds embeddings; the Inspector will connect only after startup completes. Watch the terminal for progress logs printed to stderr.
+- You can also put settings in a `.env` file at the project root (e.g., `REPO_ROOT`, `TRANSFORMERS_CACHE`, `EMBEDDING_PROVIDER`, `EMBEDDING_API_BASE_URL`).
 
 In the Inspector UI:
 
@@ -253,17 +285,20 @@ Supported variables:
 
 - `REPO_ROOT` (required): path to the repository to index.
 - `FOLDER_INFO_NAME` (optional): display label used inside MCP tool descriptions for the repository root (default `REPO_ROOT`). This is purely cosmetic for client UX; it does NOT affect which directory is indexed (that is controlled only by `REPO_ROOT`). Set it if you prefer a friendlier name (e.g., `frontend-app` or `monorepo-root`) to appear in tool metadata and path guidance returned to the client.
-- `TRANSFORMERS_CACHE` (optional): cache folder for model files.
+- `EMBEDDING_PROVIDER` (optional): `local` (default) or `openai`. `openai` means “use an OpenAI-compatible `/embeddings` API”, not specifically OpenAI as the vendor.
+- `TRANSFORMERS_CACHE` (optional): cache folder for local model files.
+- `EMBEDDING_API_BASE_URL` (required when `EMBEDDING_PROVIDER=openai`): base URL for the OpenAI-compatible API, such as `https://api.openai.com/v1`, `https://api.mistral.ai/v1`, or your provider-specific equivalent.
+- `EMBEDDING_API_KEY` (required when `EMBEDDING_PROVIDER=openai`): bearer token used for the embeddings API.
 - `ALLOWED_EXT` (optional): comma-separated list of file extensions to index. Default includes common text/code formats plus `pdf`. PDF files are automatically processed: text is extracted once during indexing and cached in a unified `pdf-text-cache.json` file for fast retrieval.
 - `EXCLUDED_FOLDERS` (optional): comma-separated list of folder patterns to exclude from indexing. Supports both exact folder names (e.g., `node_modules,dist,build,.git`) and basic glob patterns (e.g., `**/test/**,**/tests/**`). Files in these folders will be skipped during indexing. Defaults include common build/dependency folders: `node_modules`, `dist`, `build`, `.git`, `target`, `bin`, `obj`, `.cache`, `coverage`, `.nyc_output`.
 - `MCP_TRANSPORT` (optional): `http` or `stdio`.
 - `VERBOSE` (optional): true/1/yes/on for more granular progress logs during indexing & embedding.
 - `INDEX_STORE_PATH` (optional): base path for persisted embedding index storage (e.g., `C:\repo\.mcp-index` or `/repo/.mcp-index`). The index is stored as multiple JSON files with this prefix (e.g., `.mcp-index.part0000.json`, `.mcp-index.part0001.json`, etc.) along with a manifest file (`.mcp-index.manifest.json`) that tracks metadata, compatibility parameters, and the list of data files. Enables fast warm starts + incremental reindex (new / deleted / size‑changed files only).
-- `MODEL_NAME` (optional): override the default embedding model (`jinaai/jina-embeddings-v2-base-code`). Examples:
+- `MODEL_NAME` (optional): override the default embedding model (`jinaai/jina-embeddings-v2-base-code`). For `EMBEDDING_PROVIDER=local`, this must be a model supported by `@huggingface/transformers`. For `EMBEDDING_PROVIDER=openai`, this is passed directly to the remote `/embeddings` API. Examples:
   - `MODEL_NAME=jinaai/jina-embeddings-v2-base-code` (default) — Balanced multilingual/code embedding model; strong for mixed natural language + source code semantic search.
   - `MODEL_NAME=Xenova/bge-base-en-v1.5` — High-quality English general-purpose text embeddings (good for documentation/wiki style corpora).
   - `MODEL_NAME=Xenova/bge-small-en-v1.5` — Faster/lighter English model when latency or memory matters more than a few points of recall.
-    Any compatible sentence / feature-extraction model supported by `@huggingface/transformers` should work.
+    Any compatible sentence / feature-extraction model supported by `@huggingface/transformers` should work for local mode.
 - `HOST` (optional, HTTP mode): bind host (default `127.0.0.1`).
 - `MCP_PORT` (optional, HTTP mode): TCP port (default `3000`).
 - `ENABLE_DNS_REBINDING_PROTECTION` (optional, HTTP mode): defaults to `true`; set to `false` to disable host allow‑list checks.
@@ -299,7 +334,7 @@ Current limitations:
 - Embedding generation is sequential (no parallel batching yet).
 - Store schema is minimal (version 1); future versions may add hashing or mtime heuristics.
 
-Force a full rebuild by deleting the manifest file (`.manifest.json`) and data files (`.part*.json`) or changing chunk/model parameters.
+Force a full rebuild by deleting the manifest file (`.manifest.json`) and data files (`.part*.json`) or changing chunk/model/provider parameters.
 
 ## Visual Studio integration (MCP)
 
@@ -331,19 +366,22 @@ Sample prompt:
 
 ## Notes
 
-- First run will download and cache the model (tens to ~100 MB) and build embeddings — this may take minutes depending on repo size.
+- First run in local mode will download and cache the model (tens to ~100 MB) and build embeddings — this may take minutes depending on repo size.
 - Logs are written to stderr (console.error) to keep MCP stdout clean.
 - For very large repos, consider adding an ANN index (`hnswlib-node`) or a hybrid BM25+embeddings setup.
 
 ### Model selection guidance
 
-Choose an embedding model based on your repository characteristics:
+Choose an embedding setup based on your repository characteristics:
+
+- `EMBEDDING_PROVIDER=local` with `jinaai/jina-embeddings-v2-base-code` (default): Use when you want a fully local workflow after the initial model download and your corpus contains a meaningful amount of source code mixed with README / design docs.
+- `EMBEDDING_PROVIDER=openai`: Use when you want a hosted embeddings service, centralized credentials, or a provider-specific managed model exposed through an OpenAI-compatible API.
 
 - `jinaai/jina-embeddings-v2-base-code` (default): Use when your corpus contains a meaningful amount of source code (multi-language) mixed with README / design docs. Provides strong cross-domain alignment for code-symbol + natural language queries.
 - `Xenova/bge-base-en-v1.5`: Use when the content is predominantly English natural language (docs, knowledge base) and you want slightly stronger pure text semantic quality.
 - `Xenova/bge-small-en-v1.5`: Use for faster startup / lower memory on constrained machines or when indexing very large repos where throughput matters.
 
-Feel free to experiment—swap via `MODEL_NAME` and rebuild the embedding cache (delete any existing cached vectors if you persist them externally).
+Feel free to experiment—swap via `MODEL_NAME` and rebuild the embedding cache (delete any existing cached vectors if you persist them externally). Changing `EMBEDDING_PROVIDER` also invalidates the persisted cache on purpose.
 
 ### Chunk sizing guidance
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Notes:
 
 - `EMBEDDING_API_BASE_URL` should point to the provider's API base (for example `https://api.openai.com/v1`), not the `/embeddings` path itself.
 - `MODEL_NAME` is passed verbatim to the remote embeddings API when `EMBEDDING_PROVIDER=openai`.
+- `EMBEDDING_API_BATCH_SIZE` controls how many chunks are sent per remote embeddings request during indexing. Default: `32`.
 - `TRANSFORMERS_CACHE` is only relevant for local inference.
 
 ### Streamable HTTP mode (recommended for large initial indexes)

--- a/README.md
+++ b/README.md
@@ -33,14 +33,22 @@ Planned / Nice‑to‑have: hybrid BM25 + embedding search, ANN acceleration (HN
 
 ## Requirements
 
-- Node.js 18+
-- Visual Studio 2022 17.14+ with GitHub Copilot (Agent mode enabled)
+- Node.js 20+
 - Path to your repository (`REPO_ROOT`)
+
+Optional MCP clients (any one is enough):
+
+- The official [MCP Inspector](https://github.com/modelcontextprotocol/inspector)
+- Visual Studio 2022 17.14+ with GitHub Copilot (Agent mode enabled)
+- VS Code with GitHub Copilot Agent mode
+- Any other MCP-aware tooling
 
 ## Install
 
+```bash
 npm install
 npm run build
+```
 
 ## Run (local test)
 
@@ -48,34 +56,37 @@ Build then start (stdio transport by default). Use either `npm start` or invoke 
 
 ### Windows PowerShell
 
-```
+```powershell
 npm run build
 $env:REPO_ROOT="C:\path\to\your-repo"; node dist/index.js
 ```
 
 Or:
 
-```
+```powershell
 $env:REPO_ROOT="C:\path\to\your-repo"; npm start
 ```
 
 ### macOS / Linux (bash/zsh)
 
-```
+```bash
 npm run build
 export REPO_ROOT="/path/to/your-repo"; node dist/index.js
 ```
 
 Or:
 
-```
+```bash
 export REPO_ROOT="/path/to/your-repo"; npm start
 ```
 
 Optionally set a model cache to speed up subsequent runs (first start downloads the model once):
 
-```
+```bash
 export TRANSFORMERS_CACHE="/path/to/cache"   # macOS/Linux
+```
+
+```powershell
 $env:TRANSFORMERS_CACHE="C:\path\to\cache" # Windows PowerShell
 ```
 
@@ -90,7 +101,7 @@ $env:REPO_ROOT="C:\path\to\your-repo"
 $env:EMBEDDING_PROVIDER="openai"
 $env:EMBEDDING_API_BASE_URL="https://api.openai.com/v1"
 $env:EMBEDDING_API_KEY="<your-api-key>"
-$env:MODEL_NAME="text-embedding-3-large"
+$env:MODEL_NAME="text-embedding-3-small"
 npm start
 ```
 
@@ -101,7 +112,7 @@ export REPO_ROOT="/path/to/your-repo"
 export EMBEDDING_PROVIDER="openai"
 export EMBEDDING_API_BASE_URL="https://api.openai.com/v1"
 export EMBEDDING_API_KEY="<your-api-key>"
-export MODEL_NAME="text-embedding-3-large"
+export MODEL_NAME="text-embedding-3-small"
 npm start
 ```
 
@@ -116,18 +127,18 @@ Notes:
 
 Run the MCP server as an HTTP endpoint and only open your IDE after `Embeddings ready.` shows (avoids client timeouts on cold start):
 
-```
+```powershell
 npm run build
 $env:REPO_ROOT="C:\path\to\your-repo"; $env:MCP_TRANSPORT="http"; npm start
 ```
 
-```
+```bash
 export REPO_ROOT="/path/to/your-repo"; MCP_TRANSPORT=http npm start
 ```
 
 Default HTTP bind: http://127.0.0.1:3000/mcp. Override with `HOST` and `MCP_PORT` envs. A readiness endpoint is available at `http://127.0.0.1:3000/health` returning JSON like:
 
-```
+```json
 {
 	"version": "0.x.y",
 	"repoRoot": "C:/abs/path",
@@ -156,6 +167,7 @@ Notes:
 
 ### Linting & Formatting
 
+- Type-check (no emit): `npm run typecheck`
 - Run ESLint (check): `npm run lint`
 - Auto-fix ESLint issues: `npm run lint:fix`
 - Format with Prettier: `npm run format`
@@ -167,28 +179,28 @@ Use the MCP Inspector to exercise the server locally and try the tools without V
 
 Windows PowerShell:
 
-```
+```powershell
 npm run build
 $env:REPO_ROOT="C:\path\to\your-repo"; npx @modelcontextprotocol/inspector node .\\dist\\index.js
 ```
 
 Streamable HTTP via Inspector (Windows):
 
-```
+```powershell
 npm run build
 $env:REPO_ROOT="C:\path\to\your-repo"; $env:MCP_TRANSPORT="http"; npx @modelcontextprotocol/inspector http://localhost:3000/mcp --transport http
 ```
 
 macOS/Linux (bash/zsh):
 
-```
+```bash
 export REPO_ROOT="/path/to/your-repo"
 npx @modelcontextprotocol/inspector node dist/index.js
 ```
 
 Streamable HTTP (macOS/Linux):
 
-```
+```bash
 export REPO_ROOT="/path/to/your-repo"; MCP_TRANSPORT=http npx @modelcontextprotocol/inspector http://localhost:3000/mcp --transport http
 ```
 
@@ -271,7 +283,7 @@ Troubleshooting
 - Slow startup: set `TRANSFORMERS_CACHE` to a fast local folder and (optionally) set `ALLOWED_EXT` (e.g., `ts,tsx,js` for TypeScript/JS only, or any list you need).
 - Path errors: `path` must be relative to `REPO_ROOT`. Absolute paths are rejected for safety.
 - Nothing appears in Inspector for minutes: the server is still initializing (model download + embedding). This is expected on first run.
-  .- Slow warm restarts: provide `INDEX_STORE_PATH` so embeddings persist and only changed files re‑embed.
+- Slow warm restarts: provide `INDEX_STORE_PATH` so embeddings persist and only changed files re‑embed.
 
 ## Environment configuration (.env)
 
@@ -318,11 +330,11 @@ Safety caps: `CHUNK_SIZE` is clamped to 8000 and `CHUNK_OVERLAP` to 4000; if ove
 
 Set `INDEX_STORE_PATH` to enable a persisted index storing chunks + embeddings across multiple JSON files. On startup:
 
-1. If the manifest file exists (`.manifest.json`) and its metadata (model name, chunk size, overlap) matches, the index is loaded from the data files referenced in the manifest.
+1. If the manifest file exists (`<INDEX_STORE_PATH>.manifest.json`) and its metadata (model name, chunk size, overlap) matches, the index is loaded from the data files referenced in the manifest.
 2. The repository is rescanned; removed files' chunks are discarded, and new or size‑changed files are re‑chunked & re‑embedded.
 3. The merged index is saved back to disk (cold build path also persists when configured).
 
-The manifest file contains metadata about the index (version, chunk parameters, model name, timestamp) and a list of all data files (`.part####.json`) that comprise the full index.
+The manifest file contains metadata about the index (version, chunk parameters, model name, timestamp) and a list of all data files (`<INDEX_STORE_PATH>.part####.json`) that comprise the full index.
 
 Benefits:
 
@@ -335,7 +347,7 @@ Current limitations:
 - Embedding generation is sequential (no parallel batching yet).
 - Store schema is minimal (version 1); future versions may add hashing or mtime heuristics.
 
-Force a full rebuild by deleting the manifest file (`.manifest.json`) and data files (`.part*.json`) or changing chunk/model/provider parameters.
+Force a full rebuild by deleting the manifest file (`<INDEX_STORE_PATH>.manifest.json`) and data files (`<INDEX_STORE_PATH>.part*.json`) or changing chunk/model/provider parameters.
 
 ## Visual Studio integration (MCP)
 
@@ -348,13 +360,13 @@ Adjust the paths in "command"/"args" and the `REPO_ROOT` env.
 
 For Streamable HTTP, use a config entry like:
 
-```
+```json
 {
-	"servers": {
-		"mcp-rag-server": {
-			"url": "http://127.0.0.1:3000/mcp"
-		}
-	}
+  "servers": {
+    "mcp-rag-server": {
+      "url": "http://127.0.0.1:3000/mcp"
+    }
+  }
 }
 ```
 
@@ -373,16 +385,22 @@ Sample prompt:
 
 ### Model selection guidance
 
-Choose an embedding setup based on your repository characteristics:
+Choose an embedding setup based on your repository characteristics. There are two orthogonal choices: **provider** and **model**.
 
-- `EMBEDDING_PROVIDER=local` with `jinaai/jina-embeddings-v2-base-code` (default): Use when you want a fully local workflow after the initial model download and your corpus contains a meaningful amount of source code mixed with README / design docs.
-- `EMBEDDING_PROVIDER=openai`: Use when you want a hosted embeddings service, centralized credentials, or a provider-specific managed model exposed through an OpenAI-compatible API.
+**Provider** (`EMBEDDING_PROVIDER`):
 
-- `jinaai/jina-embeddings-v2-base-code` (default): Use when your corpus contains a meaningful amount of source code (multi-language) mixed with README / design docs. Provides strong cross-domain alignment for code-symbol + natural language queries.
-- `Xenova/bge-base-en-v1.5`: Use when the content is predominantly English natural language (docs, knowledge base) and you want slightly stronger pure text semantic quality.
-- `Xenova/bge-small-en-v1.5`: Use for faster startup / lower memory on constrained machines or when indexing very large repos where throughput matters.
+- `local` (default): fully local workflow after the initial model download via `@huggingface/transformers`. No outbound network calls at query time.
+- `openai`: hosted embeddings via any OpenAI-compatible `/embeddings` API (OpenAI, Mistral, Jina AI, etc.). Use for centralized credentials or larger managed models.
 
-Feel free to experiment—swap via `MODEL_NAME` and rebuild the embedding cache (delete any existing cached vectors if you persist them externally). Changing `EMBEDDING_PROVIDER` also invalidates the persisted cache on purpose.
+**Model** (`MODEL_NAME`):
+
+- `jinaai/jina-embeddings-v2-base-code` (local default): balanced multilingual/code embedding model. Use when your corpus contains a meaningful amount of source code mixed with README / design docs. Strong cross-domain alignment for code-symbol + natural language queries.
+- `Xenova/bge-base-en-v1.5` (local): high-quality English general-purpose text embeddings. Use when content is predominantly English natural language (docs, knowledge base).
+- `Xenova/bge-small-en-v1.5` (local): faster/lighter English model. Use for lower memory or when indexing very large repos where throughput matters more than a few points of recall.
+- `text-embedding-3-small` (openai, **preferred**): fast, cost-efficient hosted model with strong general-purpose quality. Good default when `EMBEDDING_PROVIDER=openai`.
+- `text-embedding-3-large` (openai): higher-dimensional model for maximum recall quality; higher cost and latency than `text-embedding-3-small`.
+
+Feel free to experiment—swap via `MODEL_NAME` and rebuild the embedding cache (delete any existing cached vectors if you persist them externally). Changing `EMBEDDING_PROVIDER` or `MODEL_NAME` invalidates the persisted index on purpose.
 
 ### Chunk sizing guidance
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Two transports are supported (select with `MCP_TRANSPORT=stdio|http`):
 - Incremental change detection (additions / deletions / file size changes) to avoid full rebuilds
 - Stdio or Streamable HTTP transport (with optional host allow‑list / DNS rebinding protection)
 - Safe path handling (rejects attempts to escape `REPO_ROOT`)
-- Minimal dependencies; quick startup after first local model load or remote API validation
+- Minimal dependencies; quick startup after first local model load or remote API configuration validation
 - Ready for extension: add new MCP tools or ANN / hybrid retrieval backends
 
 Planned / Nice‑to‑have: hybrid BM25 + embedding search, ANN acceleration (HNSW / IVF), per‑language tokenizer heuristics, batched / parallel embedding, semantic boundary aware chunking.
@@ -345,7 +345,7 @@ Benefits:
 Current limitations:
 
 - Change detection uses file size only (content edits keeping identical size won't re‑embed yet).
-- Embedding generation is sequential (no parallel batching yet).
+- Embedding generation is not parallelized yet; OpenAI‑compatible providers support request batching, but local embeddings still run one chunk at a time.
 - Store schema is minimal (version 1); future versions may add hashing or mtime heuristics.
 
 Force a full rebuild by deleting the manifest file (`<INDEX_STORE_PATH>.manifest.json`) and data files (`<INDEX_STORE_PATH>.part*.json`) or changing chunk/model/provider parameters.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Notes:
 
 - `EMBEDDING_API_BASE_URL` should point to the provider's API base (for example `https://api.openai.com/v1`), not the `/embeddings` path itself.
 - `MODEL_NAME` is passed verbatim to the remote embeddings API when `EMBEDDING_PROVIDER=openai`.
-- `EMBEDDING_API_BATCH_SIZE` controls how many chunks are sent per remote embeddings request during indexing. Default: `32`.
+- `EMBEDDING_API_BATCH_SIZE` controls how many chunks are sent per remote embeddings request during indexing. Default: `200`.
 - `TRANSFORMERS_CACHE` is only relevant for local inference.
 
 ### Streamable HTTP mode (recommended for large initial indexes)
@@ -302,6 +302,7 @@ Supported variables:
 - `TRANSFORMERS_CACHE` (optional): cache folder for local model files.
 - `EMBEDDING_API_BASE_URL` (required when `EMBEDDING_PROVIDER=openai`): base URL for the OpenAI-compatible API, such as `https://api.openai.com/v1`, `https://api.mistral.ai/v1`, or your provider-specific equivalent.
 - `EMBEDDING_API_KEY` (required when `EMBEDDING_PROVIDER=openai`): bearer token used for the embeddings API.
+- `EMBEDDING_API_BATCH_SIZE` (optional when `EMBEDDING_PROVIDER=openai`): number of chunks sent per remote embeddings request during indexing. Default: `200`.
 - `ALLOWED_EXT` (optional): comma-separated list of file extensions to index. Default includes common text/code formats plus `pdf`. PDF files are automatically processed: text is extracted once during indexing and cached in a unified `pdf-text-cache.json` file for fast retrieval.
 - `EXCLUDED_FOLDERS` (optional): comma-separated list of folder patterns to exclude from indexing. Supports both exact folder names (e.g., `node_modules,dist,build,.git`) and basic glob patterns (e.g., `**/test/**,**/tests/**`). Files in these folders will be skipped during indexing. Defaults include common build/dependency folders: `node_modules`, `dist`, `build`, `.git`, `target`, `bin`, `obj`, `.cache`, `coverage`, `.nyc_output`.
 - `MCP_TRANSPORT` (optional): `http` or `stdio`.
@@ -317,9 +318,9 @@ Supported variables:
 - `ENABLE_DNS_REBINDING_PROTECTION` (optional, HTTP mode): defaults to `true`; set to `false` to disable host allow‑list checks.
 - `ALLOWED_HOSTS` (optional, HTTP mode): comma-separated list of hosts allowed when DNS rebinding protection is enabled. Defaults include localhost and 127.0.0.1 with/without port.
 - `CHUNK_SIZE` (optional): maximum characters per chunk before embedding (default 2400, roughly 800 tokens depending on tokenizer/model). Larger values reduce total embeddings (faster build, less memory) but can blur fine-grained matches. Typical ranges:
-	- 2100‑2700 (roughly 700‑900 tokens; balanced default)
-	- 3000‑4200 (roughly 1000‑1400 tokens; large prose / long functions; fewer vectors)
-	- 1200‑1800 (roughly 400‑600 tokens; fine‑grained code navigation; more vectors / memory)
+  - 2100‑2700 (roughly 700‑900 tokens; balanced default)
+  - 3000‑4200 (roughly 1000‑1400 tokens; large prose / long functions; fewer vectors)
+  - 1200‑1800 (roughly 400‑600 tokens; fine‑grained code navigation; more vectors / memory)
 - `CHUNK_OVERLAP` (optional): trailing characters carried into the next chunk (default 400, roughly 120 tokens or about 15% of the default chunk size). Recommended 10‑20% of `CHUNK_SIZE` (for example 240‑540 when `CHUNK_SIZE=2400`). Increase slightly (up to ~20‑25%) if you observe answers missing cross‑boundary context; decrease to speed up builds.
 
 Safety caps: `CHUNK_SIZE` is clamped to 8000 and `CHUNK_OVERLAP` to 4000; if overlap >= size it's automatically reduced (logged) to preserve forward progress.

--- a/example.mcp.json
+++ b/example.mcp.json
@@ -3,7 +3,7 @@
     "mcp-rag-server": {
       "type": "stdio",
       "command": "node",
-      "args": ["C:/path/to/mcp-rag-server/build/index.js"],
+      "args": ["C:/path/to/mcp-rag-server/dist/index.js"],
       "env": {
         "REPO_ROOT": "C:/path/to/your/repository",
         "TRANSFORMERS_CACHE": "C:/path/to/cache",

--- a/src/config.ts
+++ b/src/config.ts
@@ -130,12 +130,12 @@ export async function getConfig(): Promise<Config> {
   // Verbosity toggle
   const VERBOSE = parseEnvBool(process.env.VERBOSE);
 
-  // Chunk sizing (optional env overrides; defaults 800 / 120)
+  // Chunk sizing (optional env overrides; defaults 2400 / 400)
   // Chunk size impacts recall (too large) vs. precision (too small). Trade‑off is tunable.
-  const CHUNK_SIZE = parseEnvNumber(process.env.CHUNK_SIZE, 800, 1, 8000);
+  const CHUNK_SIZE = parseEnvNumber(process.env.CHUNK_SIZE, 2400, 1, 8000);
 
   // Overlap helps preserve context continuity across semantic chunks.
-  const CHUNK_OVERLAP = parseEnvNumber(process.env.CHUNK_OVERLAP, 120, 0, 4000);
+  const CHUNK_OVERLAP = parseEnvNumber(process.env.CHUNK_OVERLAP, 400, 0, 4000);
 
   // Human‑friendly label used purely in tool descriptions; does not affect disk paths.
   const FOLDER_INFO_NAME = process.env.FOLDER_INFO_NAME?.trim() || "REPO_ROOT";

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -226,7 +226,10 @@ export class Embeddings {
       return embedding!;
     }
 
-    const output = await this.embedder!(trimmed, { pooling: "mean", normalize: true });
+    const output = await this.embedder!(trimmed.length > 0 ? trimmed : " ", {
+      pooling: "mean",
+      normalize: true,
+    });
     return output.data as Float32Array;
   }
 

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -4,18 +4,13 @@ import { pipeline, FeatureExtractionPipeline } from "@huggingface/transformers";
 const COSINE_EPSILON = 1e-10;
 
 /** Default number of inputs to send in one OpenAI-compatible embeddings request. */
-const DEFAULT_OPENAI_EMBEDDING_BATCH_SIZE = 32;
-
-/** Placeholder sent when a trimmed input is empty and the remote API rejects blank strings. */
-const EMPTY_OPENAI_EMBEDDING_INPUT_PLACEHOLDER = " ";
+const DEFAULT_OPENAI_EMBEDDING_BATCH_SIZE = 50;
 
 /** Default embedding model used when none is specified. */
 export const DEFAULT_EMBEDDING_MODEL = "jinaai/jina-embeddings-v2-base-code";
 
 /** Supported embedding backends. */
 export type EmbeddingProvider = "local" | "openai";
-
-const DEFAULT_EMBEDDING_PROVIDER: EmbeddingProvider = "local";
 
 /** Error thrown when attempting to embed before initialization. */
 export class EmbedderNotInitializedError extends Error {
@@ -33,38 +28,7 @@ export class EmbeddingConfigError extends Error {
   }
 }
 
-function resolveEmbeddingProvider(rawProvider: string | undefined): EmbeddingProvider {
-  const provider = rawProvider?.trim().toLowerCase();
-  if (!provider) return DEFAULT_EMBEDDING_PROVIDER;
-  if (provider === "local" || provider === "openai") return provider;
-  throw new EmbeddingConfigError(
-    `Unsupported EMBEDDING_PROVIDER '${rawProvider}'. Expected 'local' or 'openai'.`,
-  );
-}
-
-function ensureUrlHasTrailingSlash(value: string): string {
-  return value.endsWith("/") ? value : `${value}/`;
-}
-
-function resolveOpenAiBatchSize(rawValue: string | undefined): number {
-  if (!rawValue?.trim()) {
-    return DEFAULT_OPENAI_EMBEDDING_BATCH_SIZE;
-  }
-
-  const parsed = Number.parseInt(rawValue, 10);
-  if (!Number.isInteger(parsed) || parsed <= 0) {
-    throw new EmbeddingConfigError(
-      `EMBEDDING_API_BATCH_SIZE must be a positive integer. Received '${rawValue}'.`,
-    );
-  }
-
-  return parsed;
-}
-
-function normalizeOpenAiEmbeddingInput(text: string): string {
-  return text.length > 0 ? text : EMPTY_OPENAI_EMBEDDING_INPUT_PLACEHOLDER;
-}
-
+/** Converts a raw API embedding array to a typed Float32Array, validating numeric values. */
 function toEmbeddingVector(values: unknown): Float32Array {
   if (!Array.isArray(values) || values.length === 0) {
     throw new Error("[MCP] Invalid embeddings API response: missing embedding vector.");
@@ -83,6 +47,10 @@ function toEmbeddingVector(values: unknown): Float32Array {
   return new Float32Array(normalized);
 }
 
+/**
+ * Converts the `data` array from an OpenAI-compatible embeddings response into ordered
+ * Float32Array vectors, sorting by the `index` field to handle out-of-order responses.
+ */
 function toEmbeddingVectors(
   data: Array<{
     embedding?: unknown;
@@ -96,41 +64,9 @@ function toEmbeddingVectors(
     );
   }
 
-  const vectors = new Array<Float32Array>(expectedCount);
-  let nextSequentialIndex = 0;
-
-  for (const item of data) {
-    const responseIndex = Number(item.index);
-    let targetIndex: number;
-    if (
-      Number.isInteger(responseIndex) &&
-      responseIndex >= 0 &&
-      responseIndex < expectedCount &&
-      !vectors[responseIndex]
-    ) {
-      targetIndex = responseIndex;
-    } else {
-      while (nextSequentialIndex < expectedCount && vectors[nextSequentialIndex]) {
-        nextSequentialIndex++;
-      }
-      targetIndex = nextSequentialIndex;
-    }
-
-    if (targetIndex >= expectedCount) {
-      throw new Error("[MCP] Invalid embeddings API response: duplicate embedding index.");
-    }
-
-    vectors[targetIndex] = toEmbeddingVector(item.embedding);
-    if (targetIndex === nextSequentialIndex) {
-      nextSequentialIndex++;
-    }
-  }
-
-  if (vectors.some((vector) => !vector)) {
-    throw new Error("[MCP] Invalid embeddings API response: missing embedding entries.");
-  }
-
-  return vectors;
+  return [...data]
+    .sort((a, b) => Number(a.index) - Number(b.index))
+    .map((item) => toEmbeddingVector(item.embedding));
 }
 
 /**
@@ -148,12 +84,34 @@ export class Embeddings {
   private initialized = false;
 
   public constructor(modelName?: string) {
-    this.provider = resolveEmbeddingProvider(process.env.EMBEDDING_PROVIDER);
+    const rawProvider = process.env.EMBEDDING_PROVIDER?.trim().toLowerCase();
+    if (!rawProvider) {
+      this.provider = "local";
+    } else if (rawProvider === "local" || rawProvider === "openai") {
+      this.provider = rawProvider;
+    } else {
+      throw new EmbeddingConfigError(
+        `Unsupported EMBEDDING_PROVIDER '${process.env.EMBEDDING_PROVIDER}'. Expected 'local' or 'openai'.`,
+      );
+    }
+
     // Resolution precedence: explicit ctor arg > MODEL_NAME env var > default model
     this.modelName = modelName?.trim() || process.env.MODEL_NAME?.trim() || DEFAULT_EMBEDDING_MODEL;
     this.apiBaseUrl = process.env.EMBEDDING_API_BASE_URL?.trim() || null;
     this.apiKey = process.env.EMBEDDING_API_KEY?.trim() || null;
-    this.apiBatchSize = resolveOpenAiBatchSize(process.env.EMBEDDING_API_BATCH_SIZE);
+
+    const rawBatchSize = process.env.EMBEDDING_API_BATCH_SIZE;
+    if (!rawBatchSize?.trim()) {
+      this.apiBatchSize = DEFAULT_OPENAI_EMBEDDING_BATCH_SIZE;
+    } else {
+      const parsed = Number.parseInt(rawBatchSize, 10);
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw new EmbeddingConfigError(
+          `EMBEDDING_API_BATCH_SIZE must be a positive integer. Received '${rawBatchSize}'.`,
+        );
+      }
+      this.apiBatchSize = parsed;
+    }
   }
 
   /** @returns Resolved (possibly defaulted) underlying model identifier. */
@@ -171,6 +129,7 @@ export class Embeddings {
     return this.provider === "openai" ? this.apiBatchSize : 1;
   }
 
+  /** Builds and returns the resolved embeddings endpoint URL. Throws if the base URL is missing or invalid. */
   private getApiEmbeddingsEndpoint(): URL {
     if (!this.apiBaseUrl) {
       throw new EmbeddingConfigError(
@@ -179,19 +138,11 @@ export class Embeddings {
     }
 
     try {
-      return new URL("embeddings", ensureUrlHasTrailingSlash(this.apiBaseUrl));
+      const base = this.apiBaseUrl.endsWith("/") ? this.apiBaseUrl : `${this.apiBaseUrl}/`;
+      return new URL("embeddings", base);
     } catch {
       throw new EmbeddingConfigError(
         `EMBEDDING_API_BASE_URL must be a valid URL. Received '${this.apiBaseUrl}'.`,
-      );
-    }
-  }
-
-  private validateApiConfiguration(): void {
-    this.getApiEmbeddingsEndpoint();
-    if (!this.apiKey) {
-      throw new EmbeddingConfigError(
-        "EMBEDDING_API_KEY is required when EMBEDDING_PROVIDER=openai.",
       );
     }
   }
@@ -201,7 +152,13 @@ export class Embeddings {
     if (this.initialized) return;
 
     if (this.provider === "openai") {
-      this.validateApiConfiguration();
+      // Validate API configuration; getApiEmbeddingsEndpoint throws if base URL is missing/invalid.
+      this.getApiEmbeddingsEndpoint();
+      if (!this.apiKey) {
+        throw new EmbeddingConfigError(
+          "EMBEDDING_API_KEY is required when EMBEDDING_PROVIDER=openai.",
+        );
+      }
       console.error(`[MCP] Using embeddings API: ${this.getApiEmbeddingsEndpoint().toString()}`);
       console.error(`[MCP] Remote embedding model configured: ${this.modelName}`);
       console.error(`[MCP] Remote embedding batch size: ${this.apiBatchSize}`);
@@ -217,8 +174,10 @@ export class Embeddings {
     this.initialized = true;
   }
 
+  /** Sends a single HTTP request to the embeddings API and returns the resulting vectors. */
   private async embedViaApiBatch(texts: string[]): Promise<Float32Array[]> {
-    const normalizedTexts = texts.map(normalizeOpenAiEmbeddingInput);
+    // Some remote APIs reject empty strings; substitute a single space.
+    const normalizedTexts = texts.map((text) => (text.length > 0 ? text : " "));
     const response = await fetch(this.getApiEmbeddingsEndpoint(), {
       method: "POST",
       headers: {
@@ -248,14 +207,6 @@ export class Embeddings {
     return toEmbeddingVectors(payload.data ?? [], normalizedTexts.length);
   }
 
-  private async embedViaApi(text: string): Promise<Float32Array> {
-    const [embedding] = await this.embedViaApiBatch([text]);
-    if (!embedding) {
-      throw new Error("[MCP] Invalid embeddings API response: missing embedding vector.");
-    }
-    return embedding;
-  }
-
   /**
    * Compute an embedding for a single text string using mean pooling and
    * L2 normalization (as provided by the pipeline options).
@@ -271,11 +222,11 @@ export class Embeddings {
     const trimmed = text.trim();
 
     if (this.provider === "openai") {
-      return await this.embedViaApi(trimmed);
+      const [embedding] = await this.embedViaApiBatch([trimmed]);
+      return embedding!;
     }
 
-    if (!this.embedder) throw new EmbedderNotInitializedError();
-    const output = await this.embedder(trimmed, { pooling: "mean", normalize: true });
+    const output = await this.embedder!(trimmed, { pooling: "mean", normalize: true });
     return output.data as Float32Array;
   }
 

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -4,7 +4,7 @@ import { pipeline, FeatureExtractionPipeline } from "@huggingface/transformers";
 const COSINE_EPSILON = 1e-10;
 
 /** Default number of inputs to send in one OpenAI-compatible embeddings request. */
-const DEFAULT_OPENAI_EMBEDDING_BATCH_SIZE = 50;
+const DEFAULT_OPENAI_EMBEDDING_BATCH_SIZE = 200;
 
 /** Default embedding model used when none is specified. */
 export const DEFAULT_EMBEDDING_MODEL = "jinaai/jina-embeddings-v2-base-code";

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -6,12 +6,56 @@ const COSINE_EPSILON = 1e-10;
 /** Default embedding model used when none is specified. */
 export const DEFAULT_EMBEDDING_MODEL = "jinaai/jina-embeddings-v2-base-code";
 
+/** Supported embedding backends. */
+export type EmbeddingProvider = "local" | "openai";
+
+const DEFAULT_EMBEDDING_PROVIDER: EmbeddingProvider = "local";
+
 /** Error thrown when attempting to embed before initialization. */
 export class EmbedderNotInitializedError extends Error {
   constructor() {
     super("Embedder not initialized. Call init() first.");
     this.name = "EmbedderNotInitializedError";
   }
+}
+
+/** Error thrown when embedding provider configuration is invalid. */
+export class EmbeddingConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EmbeddingConfigError";
+  }
+}
+
+function resolveEmbeddingProvider(rawProvider: string | undefined): EmbeddingProvider {
+  const provider = rawProvider?.trim().toLowerCase();
+  if (!provider) return DEFAULT_EMBEDDING_PROVIDER;
+  if (provider === "local" || provider === "openai") return provider;
+  throw new EmbeddingConfigError(
+    `Unsupported EMBEDDING_PROVIDER '${rawProvider}'. Expected 'local' or 'openai'.`,
+  );
+}
+
+function ensureUrlHasTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value : `${value}/`;
+}
+
+function toEmbeddingVector(values: unknown): Float32Array {
+  if (!Array.isArray(values) || values.length === 0) {
+    throw new Error("[MCP] Invalid embeddings API response: missing embedding vector.");
+  }
+
+  const normalized = values.map((value) => {
+    const numericValue = Number(value);
+    if (!Number.isFinite(numericValue)) {
+      throw new Error(
+        "[MCP] Invalid embeddings API response: embedding contains non-numeric values.",
+      );
+    }
+    return numericValue;
+  });
+
+  return new Float32Array(normalized);
 }
 
 /**
@@ -21,11 +65,18 @@ export class EmbedderNotInitializedError extends Error {
  */
 export class Embeddings {
   private readonly modelName: string;
+  private readonly provider: EmbeddingProvider;
+  private readonly apiBaseUrl: string | null;
+  private readonly apiKey: string | null;
   private embedder: FeatureExtractionPipeline | null = null;
+  private initialized = false;
 
   public constructor(modelName?: string) {
+    this.provider = resolveEmbeddingProvider(process.env.EMBEDDING_PROVIDER);
     // Resolution precedence: explicit ctor arg > MODEL_NAME env var > default model
     this.modelName = modelName?.trim() || process.env.MODEL_NAME?.trim() || DEFAULT_EMBEDDING_MODEL;
+    this.apiBaseUrl = process.env.EMBEDDING_API_BASE_URL?.trim() || null;
+    this.apiKey = process.env.EMBEDDING_API_KEY?.trim() || null;
   }
 
   /** @returns Resolved (possibly defaulted) underlying model identifier. */
@@ -33,14 +84,83 @@ export class Embeddings {
     return this.modelName;
   }
 
+  /** @returns Stable provider/model identity for persistence compatibility checks. */
+  public getModelIdentity(): string {
+    return `${this.provider}:${this.modelName}`;
+  }
+
+  private getApiEmbeddingsEndpoint(): URL {
+    if (!this.apiBaseUrl) {
+      throw new EmbeddingConfigError(
+        "EMBEDDING_API_BASE_URL is required when EMBEDDING_PROVIDER=openai.",
+      );
+    }
+
+    try {
+      return new URL("embeddings", ensureUrlHasTrailingSlash(this.apiBaseUrl));
+    } catch {
+      throw new EmbeddingConfigError(
+        `EMBEDDING_API_BASE_URL must be a valid URL. Received '${this.apiBaseUrl}'.`,
+      );
+    }
+  }
+
+  private validateApiConfiguration(): void {
+    this.getApiEmbeddingsEndpoint();
+    if (!this.apiKey) {
+      throw new EmbeddingConfigError(
+        "EMBEDDING_API_KEY is required when EMBEDDING_PROVIDER=openai.",
+      );
+    }
+  }
+
   /** Lazily initialize the underlying embedding pipeline (idempotent). */
   public async init(): Promise<void> {
-    if (this.embedder) return; // already initialized
+    if (this.initialized) return;
+
+    if (this.provider === "openai") {
+      this.validateApiConfiguration();
+      console.error(`[MCP] Using embeddings API: ${this.getApiEmbeddingsEndpoint().toString()}`);
+      console.error(`[MCP] Remote embedding model configured: ${this.modelName}`);
+      this.initialized = true;
+      return;
+    }
+
     console.error(`[MCP] Loading embedding model: ${this.modelName}`);
     this.embedder = (await (pipeline as any)("feature-extraction", this.modelName, {
       dtype: "q8", // Use quantized model for smaller download size
     })) as FeatureExtractionPipeline;
     console.error(`[MCP] Model ready: ${this.modelName}`);
+    this.initialized = true;
+  }
+
+  private async embedViaApi(text: string): Promise<Float32Array> {
+    const response = await fetch(this.getApiEmbeddingsEndpoint(), {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: this.modelName,
+        input: text,
+        encoding_format: "float",
+      }),
+    });
+
+    if (!response.ok) {
+      const detail = await response.text().catch(() => response.statusText);
+      throw new Error(
+        `[MCP] Embeddings API request failed (${response.status} ${response.statusText}): ${detail.slice(0, 400)}`,
+      );
+    }
+
+    const payload = (await response.json()) as {
+      data?: Array<{
+        embedding?: unknown;
+      }>;
+    };
+    return toEmbeddingVector(payload.data?.[0]?.embedding);
   }
 
   /**
@@ -54,8 +174,14 @@ export class Embeddings {
    * @throws {EmptyTextError} If text is empty or whitespace-only.
    */
   public async embed(text: string): Promise<Float32Array> {
-    if (!this.embedder) throw new EmbedderNotInitializedError();
+    if (!this.initialized) throw new EmbedderNotInitializedError();
     const trimmed = text.trim();
+
+    if (this.provider === "openai") {
+      return await this.embedViaApi(trimmed);
+    }
+
+    if (!this.embedder) throw new EmbedderNotInitializedError();
     const output = await this.embedder(trimmed, { pooling: "mean", normalize: true });
     return output.data as Float32Array;
   }

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -3,6 +3,12 @@ import { pipeline, FeatureExtractionPipeline } from "@huggingface/transformers";
 /** Small epsilon value to prevent division by zero in cosine similarity. */
 const COSINE_EPSILON = 1e-10;
 
+/** Default number of inputs to send in one OpenAI-compatible embeddings request. */
+const DEFAULT_OPENAI_EMBEDDING_BATCH_SIZE = 32;
+
+/** Placeholder sent when a trimmed input is empty and the remote API rejects blank strings. */
+const EMPTY_OPENAI_EMBEDDING_INPUT_PLACEHOLDER = " ";
+
 /** Default embedding model used when none is specified. */
 export const DEFAULT_EMBEDDING_MODEL = "jinaai/jina-embeddings-v2-base-code";
 
@@ -40,6 +46,25 @@ function ensureUrlHasTrailingSlash(value: string): string {
   return value.endsWith("/") ? value : `${value}/`;
 }
 
+function resolveOpenAiBatchSize(rawValue: string | undefined): number {
+  if (!rawValue?.trim()) {
+    return DEFAULT_OPENAI_EMBEDDING_BATCH_SIZE;
+  }
+
+  const parsed = Number.parseInt(rawValue, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new EmbeddingConfigError(
+      `EMBEDDING_API_BATCH_SIZE must be a positive integer. Received '${rawValue}'.`,
+    );
+  }
+
+  return parsed;
+}
+
+function normalizeOpenAiEmbeddingInput(text: string): string {
+  return text.length > 0 ? text : EMPTY_OPENAI_EMBEDDING_INPUT_PLACEHOLDER;
+}
+
 function toEmbeddingVector(values: unknown): Float32Array {
   if (!Array.isArray(values) || values.length === 0) {
     throw new Error("[MCP] Invalid embeddings API response: missing embedding vector.");
@@ -58,6 +83,56 @@ function toEmbeddingVector(values: unknown): Float32Array {
   return new Float32Array(normalized);
 }
 
+function toEmbeddingVectors(
+  data: Array<{
+    embedding?: unknown;
+    index?: unknown;
+  }>,
+  expectedCount: number,
+): Float32Array[] {
+  if (data.length !== expectedCount) {
+    throw new Error(
+      `[MCP] Invalid embeddings API response: expected ${expectedCount} embeddings, received ${data.length}.`,
+    );
+  }
+
+  const vectors = new Array<Float32Array>(expectedCount);
+  let nextSequentialIndex = 0;
+
+  for (const item of data) {
+    const responseIndex = Number(item.index);
+    let targetIndex: number;
+    if (
+      Number.isInteger(responseIndex) &&
+      responseIndex >= 0 &&
+      responseIndex < expectedCount &&
+      !vectors[responseIndex]
+    ) {
+      targetIndex = responseIndex;
+    } else {
+      while (nextSequentialIndex < expectedCount && vectors[nextSequentialIndex]) {
+        nextSequentialIndex++;
+      }
+      targetIndex = nextSequentialIndex;
+    }
+
+    if (targetIndex >= expectedCount) {
+      throw new Error("[MCP] Invalid embeddings API response: duplicate embedding index.");
+    }
+
+    vectors[targetIndex] = toEmbeddingVector(item.embedding);
+    if (targetIndex === nextSequentialIndex) {
+      nextSequentialIndex++;
+    }
+  }
+
+  if (vectors.some((vector) => !vector)) {
+    throw new Error("[MCP] Invalid embeddings API response: missing embedding entries.");
+  }
+
+  return vectors;
+}
+
 /**
  * Encapsulates embedding model initialization and helper utilities for
  * generating embeddings + computing cosine similarity.
@@ -68,6 +143,7 @@ export class Embeddings {
   private readonly provider: EmbeddingProvider;
   private readonly apiBaseUrl: string | null;
   private readonly apiKey: string | null;
+  private readonly apiBatchSize: number;
   private embedder: FeatureExtractionPipeline | null = null;
   private initialized = false;
 
@@ -77,6 +153,7 @@ export class Embeddings {
     this.modelName = modelName?.trim() || process.env.MODEL_NAME?.trim() || DEFAULT_EMBEDDING_MODEL;
     this.apiBaseUrl = process.env.EMBEDDING_API_BASE_URL?.trim() || null;
     this.apiKey = process.env.EMBEDDING_API_KEY?.trim() || null;
+    this.apiBatchSize = resolveOpenAiBatchSize(process.env.EMBEDDING_API_BATCH_SIZE);
   }
 
   /** @returns Resolved (possibly defaulted) underlying model identifier. */
@@ -87,6 +164,11 @@ export class Embeddings {
   /** @returns Stable provider/model identity for persistence compatibility checks. */
   public getModelIdentity(): string {
     return `${this.provider}:${this.modelName}`;
+  }
+
+  /** @returns Recommended request batch size for indexing operations. */
+  public getBatchSize(): number {
+    return this.provider === "openai" ? this.apiBatchSize : 1;
   }
 
   private getApiEmbeddingsEndpoint(): URL {
@@ -122,6 +204,7 @@ export class Embeddings {
       this.validateApiConfiguration();
       console.error(`[MCP] Using embeddings API: ${this.getApiEmbeddingsEndpoint().toString()}`);
       console.error(`[MCP] Remote embedding model configured: ${this.modelName}`);
+      console.error(`[MCP] Remote embedding batch size: ${this.apiBatchSize}`);
       this.initialized = true;
       return;
     }
@@ -134,7 +217,8 @@ export class Embeddings {
     this.initialized = true;
   }
 
-  private async embedViaApi(text: string): Promise<Float32Array> {
+  private async embedViaApiBatch(texts: string[]): Promise<Float32Array[]> {
+    const normalizedTexts = texts.map(normalizeOpenAiEmbeddingInput);
     const response = await fetch(this.getApiEmbeddingsEndpoint(), {
       method: "POST",
       headers: {
@@ -143,7 +227,7 @@ export class Embeddings {
       },
       body: JSON.stringify({
         model: this.modelName,
-        input: text,
+        input: normalizedTexts,
         encoding_format: "float",
       }),
     });
@@ -158,9 +242,18 @@ export class Embeddings {
     const payload = (await response.json()) as {
       data?: Array<{
         embedding?: unknown;
+        index?: unknown;
       }>;
     };
-    return toEmbeddingVector(payload.data?.[0]?.embedding);
+    return toEmbeddingVectors(payload.data ?? [], normalizedTexts.length);
+  }
+
+  private async embedViaApi(text: string): Promise<Float32Array> {
+    const [embedding] = await this.embedViaApiBatch([text]);
+    if (!embedding) {
+      throw new Error("[MCP] Invalid embeddings API response: missing embedding vector.");
+    }
+    return embedding;
   }
 
   /**
@@ -184,6 +277,34 @@ export class Embeddings {
     if (!this.embedder) throw new EmbedderNotInitializedError();
     const output = await this.embedder(trimmed, { pooling: "mean", normalize: true });
     return output.data as Float32Array;
+  }
+
+  /**
+   * Compute embeddings for multiple text strings. OpenAI-compatible providers are
+   * called in request batches; local inference falls back to the existing
+   * single-item path to preserve current behavior.
+   */
+  public async embedMany(texts: string[]): Promise<Float32Array[]> {
+    if (!this.initialized) throw new EmbedderNotInitializedError();
+    if (texts.length === 0) return [];
+
+    const trimmedTexts = texts.map((text) => text.trim());
+
+    if (this.provider === "openai") {
+      const embeddings: Float32Array[] = [];
+      for (let i = 0; i < trimmedTexts.length; i += this.apiBatchSize) {
+        embeddings.push(
+          ...(await this.embedViaApiBatch(trimmedTexts.slice(i, i + this.apiBatchSize))),
+        );
+      }
+      return embeddings;
+    }
+
+    const embeddings: Float32Array[] = [];
+    for (const text of trimmedTexts) {
+      embeddings.push(await this.embed(text));
+    }
+    return embeddings;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,8 +28,8 @@
  *  - ALLOWED_EXT          Comma list of file extensions to include (no leading dots).
  *  - EXCLUDED_FOLDERS     Comma list of folder names to skip during indexing.
  *  - VERBOSE              If '1'/'true'/etc enables extra logging during indexing.
- *  - CHUNK_SIZE           Max characters per text chunk (default 800, hard cap 8000).
- *  - CHUNK_OVERLAP        Overlap characters between adjacent chunks (default 120).
+ *  - CHUNK_SIZE           Max characters per text chunk (default 2400, hard cap 8000).
+ *  - CHUNK_OVERLAP        Overlap characters between adjacent chunks (default 400).
  *  - FOLDER_INFO_NAME     Display name used in tool descriptions (default 'REPO_ROOT').
  *  - EMBEDDING_PROVIDER   'local' (default) or 'openai' for an OpenAI-compatible API.
  *  - INDEX_STORE_PATH     If set, path to persist / reload serialized index artifacts.

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@
  *  - MODEL_NAME           Local HF model name or remote /embeddings model id.
  *  - EMBEDDING_API_BASE_URL Base URL for the OpenAI-compatible embeddings API.
  *  - EMBEDDING_API_KEY    Bearer token for the OpenAI-compatible embeddings API.
+ *  - EMBEDDING_API_BATCH_SIZE Number of chunks to send per remote embeddings request (default 32).
  *  - TRANSFORMERS_CACHE   Directory for local model downloads.
  *
  * NOTE: This file intentionally keeps business logic thin; heavy lifting is delegated

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@
  *  - MODEL_NAME           Local HF model name or remote /embeddings model id.
  *  - EMBEDDING_API_BASE_URL Base URL for the OpenAI-compatible embeddings API.
  *  - EMBEDDING_API_KEY    Bearer token for the OpenAI-compatible embeddings API.
- *  - EMBEDDING_API_BATCH_SIZE Number of chunks to send per remote embeddings request (default 32).
+ *  - EMBEDDING_API_BATCH_SIZE Number of chunks to send per remote embeddings request (default 200).
  *  - TRANSFORMERS_CACHE   Directory for local model downloads.
  *
  * NOTE: This file intentionally keeps business logic thin; heavy lifting is delegated

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,10 +31,14 @@
  *  - CHUNK_SIZE           Max characters per text chunk (default 800, hard cap 8000).
  *  - CHUNK_OVERLAP        Overlap characters between adjacent chunks (default 120).
  *  - FOLDER_INFO_NAME     Display name used in tool descriptions (default 'REPO_ROOT').
+ *  - EMBEDDING_PROVIDER   'local' (default) or 'openai' for an OpenAI-compatible API.
  *  - INDEX_STORE_PATH     If set, path to persist / reload serialized index artifacts.
  *  - DOCS_PER_FILE        Max documents per JSON file for persistence (default 10000, min 100).
  *  - MCP_TRANSPORT        'stdio' (default) or 'http'.
- *  - TRANSFORMERS_CACHE   Directory for model downloads (set by Embeddings.configureCache()).
+ *  - MODEL_NAME           Local HF model name or remote /embeddings model id.
+ *  - EMBEDDING_API_BASE_URL Base URL for the OpenAI-compatible embeddings API.
+ *  - EMBEDDING_API_KEY    Bearer token for the OpenAI-compatible embeddings API.
+ *  - TRANSFORMERS_CACHE   Directory for local model downloads.
  *
  * NOTE: This file intentionally keeps business logic thin; heavy lifting is delegated
  * to Embeddings + Indexer. That separation simplifies future swaps (different models,

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -243,7 +243,11 @@ export class Indexer {
       for (let batchIndex = 0; batchIndex < batch.length; batchIndex++) {
         const doc = batch[batchIndex];
         const emb = embeddings[batchIndex];
-        if (!doc || !emb) continue;
+        if (!doc || !emb) {
+          throw new Error(
+            `[MCP] Missing batch item during embedding assignment at absolute index ${i + batchIndex} (batch index ${batchIndex}).`,
+          );
+        }
         doc.emb = emb;
         statusManager.incEmbedded();
       }

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -234,7 +234,7 @@ export class Indexer {
           storePath: this.storePath,
           chunkSize: this.chunkSize,
           chunkOverlap: this.chunkOverlap,
-          modelName: this.embeddings.getModelName(),
+          modelName: this.embeddings.getModelIdentity(),
           verbose: this.verbose,
         })
       : null;
@@ -248,7 +248,7 @@ export class Indexer {
           docs: this.docs,
           chunkSize: this.chunkSize,
           chunkOverlap: this.chunkOverlap,
-          modelName: this.embeddings.getModelName(),
+          modelName: this.embeddings.getModelIdentity(),
           verbose: this.verbose,
         });
       }
@@ -314,7 +314,7 @@ export class Indexer {
         docs: this.docs,
         chunkSize: this.chunkSize,
         chunkOverlap: this.chunkOverlap,
-        modelName: this.embeddings.getModelName(),
+        modelName: this.embeddings.getModelIdentity(),
         verbose: this.verbose,
       });
     }

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -197,9 +197,9 @@ export class Indexer {
    * chunk boundaries for embedding similarity.
    *
    * @param text Full input string to divide.
-  * @param size Target maximum characters per chunk (default 2400).
+   * @param size Target maximum characters per chunk (default 2400).
    * @param overlap Number of characters of trailing overlap to retain from the
-  * previous chunk (default 400). Must be < size for forward progress.
+   * previous chunk (default 400). Must be < size for forward progress.
    * @returns Ordered list of chunk strings.
    */
   public static splitChunks(text: string, size = 2400, overlap = 400): string[] {

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -219,6 +219,38 @@ export class Indexer {
   }
 
   /**
+   * Generate embeddings for a list of docs, using provider-specific batching when available.
+   */
+  private async embedDocs(docs: Doc[], totalDocs = docs.length): Promise<void> {
+    const batchSize = Math.max(1, this.embeddings.getBatchSize());
+
+    for (let i = 0; i < docs.length; i += batchSize) {
+      if (i % 200 === 0) console.error(`[MCP] Embedding ${i}/${totalDocs}`);
+      if (this.verbose && i % 50 === 0) {
+        const pct = ((i / Math.max(1, totalDocs)) * 100).toFixed(1);
+        console.error(`[MCP][verbose] Embedding progress: ${i}/${totalDocs} (${pct}%)`);
+      }
+
+      const batch = docs.slice(i, i + batchSize);
+      const embeddings = await this.embeddings.embedMany(batch.map((doc) => doc.text));
+
+      if (embeddings.length !== batch.length) {
+        throw new Error(
+          `[MCP] Embedding provider returned ${embeddings.length} vectors for ${batch.length} docs.`,
+        );
+      }
+
+      for (let batchIndex = 0; batchIndex < batch.length; batchIndex++) {
+        const doc = batch[batchIndex];
+        const emb = embeddings[batchIndex];
+        if (!doc || !emb) continue;
+        doc.emb = emb;
+        statusManager.incEmbedded();
+      }
+    }
+  }
+
+  /**
    * Perform a full corpus (re)build: discover files, load contents, chunk, and
    * generate embeddings sequentially. Existing state is cleared first. Errors
    * reading individual files are intentionally swallowed to maximize coverage.
@@ -294,17 +326,7 @@ export class Indexer {
     );
     statusManager.setIndexTotals(fileInfos.length, this.docs.length);
 
-    for (let i = 0; i < this.docs.length; i++) {
-      const doc = this.docs[i];
-      if (!doc) continue; // Should never happen, but satisfies strict type checking
-      if (i % 200 === 0) console.error(`[MCP] Embedding ${i}/${this.docs.length}`);
-      if (this.verbose && i % 50 === 0) {
-        const pct = ((i / Math.max(1, this.docs.length)) * 100).toFixed(1);
-        console.error(`[MCP][verbose] Embedding progress: ${i}/${this.docs.length} (${pct}%)`);
-      }
-      doc.emb = await this.embeddings.embed(doc.text);
-      statusManager.incEmbedded();
-    }
+    await this.embedDocs(this.docs, this.docs.length);
     console.error(`[MCP] Embeddings ready.`);
     statusManager.markReady();
     this.built = true;
@@ -489,22 +511,21 @@ export class Indexer {
 
       const chunks = Indexer.splitChunks(content, this.chunkSize, this.chunkOverlap);
       const lineCount = content.split(/\r?\n/).length;
-      for (let idx = 0; idx < chunks.length; idx++) {
-        const text = chunks[idx];
-        if (!text) continue; // Should never happen, but satisfies strict type checking
-        const emb = await this.embeddings.embed(text);
-        this.docs.push({
-          id: `${idCounter++}`,
-          path: file.rel,
-          chunk: idx,
-          text,
-          fileSize: file.size,
-          lineCount,
-          emb,
-        });
-        statusManager.incEmbedded();
-        embeddedChunks++;
+      const newDocs: Doc[] = chunks.map((text, idx) => ({
+        id: `${idCounter + idx}`,
+        path: file.rel,
+        chunk: idx,
+        text,
+        fileSize: file.size,
+        lineCount,
+      }));
+
+      await this.embedDocs(newDocs, newDocs.length);
+      for (const doc of newDocs) {
+        this.docs.push(doc);
       }
+      idCounter += newDocs.length;
+      embeddedChunks += newDocs.length;
     }
     statusManager.setIndexTotals(currentMap.size, this.docs.length);
     // Pre-existing docs lacked embedded increment counts: credit them now.

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -56,9 +56,9 @@ export interface BuildIndexOptions {
   embeddings: Embeddings;
   /** Enable additional progress logging to stderr */
   verbose?: boolean;
-  /** Characters per chunk (default 800). Larger => fewer vectors, less locality */
+  /** Characters per chunk (default 2400). Larger => fewer vectors, less locality */
   chunkSize?: number;
-  /** Trailing character overlap between consecutive chunks (default 120) */
+  /** Trailing character overlap between consecutive chunks (default 400) */
   chunkOverlap?: number;
   /** Optional JSON persistence path (for warm start / incremental updates) */
   storePath?: string;
@@ -114,10 +114,10 @@ export class Indexer {
     this.excludedFolders = opts.excludedFolders ?? [];
     this.embeddings = opts.embeddings;
     this.verbose = !!opts.verbose;
-    this.chunkSize = opts.chunkSize ?? 800;
+    this.chunkSize = opts.chunkSize ?? 2400;
     // Resolve requested overlap then clamp if invalid (must be < chunk size). We compute
     // final value up-front so the property can remain readonly (no later mutation).
-    const requestedOverlap = opts.chunkOverlap ?? 120;
+    const requestedOverlap = opts.chunkOverlap ?? 400;
     this.chunkOverlap =
       requestedOverlap >= this.chunkSize
         ? Math.max(0, Math.floor(this.chunkSize * 0.15)) // conservative fallback (~15%)
@@ -197,12 +197,12 @@ export class Indexer {
    * chunk boundaries for embedding similarity.
    *
    * @param text Full input string to divide.
-   * @param size Target maximum characters per chunk (default 800).
+  * @param size Target maximum characters per chunk (default 2400).
    * @param overlap Number of characters of trailing overlap to retain from the
-   * previous chunk (default 120). Must be < size for forward progress.
+  * previous chunk (default 400). Must be < size for forward progress.
    * @returns Ordered list of chunk strings.
    */
-  public static splitChunks(text: string, size = 800, overlap = 120): string[] {
+  public static splitChunks(text: string, size = 2400, overlap = 400): string[] {
     // NOTE: This splitter is intentionally naïve (pure character length). For
     // better semantic coherence consider: token-aware splitting (tiktoken),
     // markdown / code block boundary detection, or AST / LSP assisted segmenting.


### PR DESCRIPTION
This pull request updates the documentation and environment configuration to support both local and OpenAI-compatible remote embedding providers, clarifies chunking defaults, and improves setup instructions. The `.env.example` and `README.md` files have been revised to explain new environment variables and usage patterns, including batch sizing, API configuration, and how to switch between local and remote embeddings. Chunk sizing defaults have been increased to better match typical token counts, and the documentation now provides clearer, more comprehensive examples for both local and remote use cases.

**Embedding provider and API configuration:**
- Added support and documentation for an `EMBEDDING_PROVIDER` setting (`local` or `openai`), including new variables for configuring remote OpenAI-compatible embedding APIs: `EMBEDDING_API_BASE_URL`, `EMBEDDING_API_KEY`, and `EMBEDDING_API_BATCH_SIZE`.

**Chunking defaults and documentation:**
- Increased the default chunk size from 800 to 2400 characters (about 800 tokens), and overlap from 120 to 400 characters (about 120 tokens), with revised explanations and recommended ranges for chunking and overlap.